### PR TITLE
Adjust nav logo size and about photo borders

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -53,7 +53,7 @@ export default function AboutPage() {
                   }`}
                 ></div>
                 <div
-                  className={`relative aspect-[3/4] overflow-hidden rounded-3xl shadow-2xl ring-1 ring-cream/10 ${
+                  className={`relative aspect-[3/4] overflow-hidden rounded-3xl shadow-2xl ring-2 ring-cream/10 ${
                     isEven ? 'md:translate-y-6' : 'md:-translate-y-6'
                   }`}
                 >

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -37,14 +37,14 @@ export function Navbar() {
             <motion.div
               whileHover={{ scale: 1.05 }}
               transition={{ duration: 0.3 }}
-              className="w-12 h-12 rounded-full overflow-hidden"
+              className="w-12 h-12 rounded-full overflow-hidden flex items-center justify-center"
             >
               <Image
                 src="/logonotext.svg"
                 alt="Northern Disconnection Logo"
-                width={48}
-                height={48}
-                className="w-full h-full object-cover"
+                width={40}
+                height={40}
+                className="w-10 h-10 object-contain"
               />
             </motion.div>
             <div>


### PR DESCRIPTION
## Summary
- center a smaller navigation logo inside the circular avatar so it fits the cut-out cleanly
- double the ring border thickness around about page photos for a bolder frame

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8921bfd648320b5e7984b0be11b63