### PR TITLE
Add New Year's Eve show at Joe's Bar in Boulder Creek

### DIFF
--- a/content/shows.json
+++ b/content/shows.json
@@ -22,6 +22,15 @@
       "soldOut": false
     },
     {
+      "date": "December 31st, 2025",
+      "time": "9:30 PM - 1:30 AM",
+      "venue": "Joe's Bar",
+      "location": "Boulder Creek, CA",
+      "description": "",
+      "hasTickets": false,
+      "soldOut": false
+    },
+    {
       "date": "January 10th, 2026",
       "time": "7-10 PM",
       "venue": "Brisbane Inn Lodge",


### PR DESCRIPTION
Added December 31st, 2025 show:
- Venue: Joe's Bar
- Location: Boulder Creek, CA
- Time: 9:30 PM - 1:30 AM
- New Year's Eve celebration

🤖 Generated with [Claude Code](https://claude.com/claude-code)