### PR TITLE
Update Big Easy show time to 7 PM

### DIFF
--- a/content/shows.json
+++ b/content/shows.json
@@ -5,7 +5,7 @@
   "upcomingShows": [
     {
       "date": "October 27th, 2025",
-      "time": "8:00 PM",
+      "time": "7:00 PM",
       "venue": "Big Easy",
       "location": "Petaluma, CA",
       "description": "",


### PR DESCRIPTION
## Summary
- update the Big Easy show listing to start at 7:00 PM instead of 8:00 PM

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe94185ee4832098ad5b009548199a