### PR TITLE
Add calendar export and accessibility improvements

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Image from 'next/image'
 import { Mail } from 'lucide-react'
+import Ornament from '@/app/components/ornament'
 
 const aboutSections = [
   {
@@ -30,7 +31,7 @@ export default function AboutPage() {
       <div className="mx-auto max-w-6xl space-y-20 px-4">
         <header className="text-center">
           <h1 className="font-display vintage-shadow text-5xl text-cream sm:text-6xl">About the Band</h1>
-          <div className="ornament mt-6 text-xl" aria-hidden="true">❦</div>
+          <Ornament className="mt-6" />
         </header>
 
         {aboutSections.map((section, index) => {

--- a/app/components/home-client.tsx
+++ b/app/components/home-client.tsx
@@ -8,6 +8,7 @@ import { Music, Calendar, Mail, MapPin } from 'lucide-react'
 import type { Show } from '@/types/content'
 import { getWeekday } from '@/lib/dates'
 import SubscribeForm from './subscribe-form'
+import Ornament from './ornament'
 
 type LatestVideo = {
   videoId: string
@@ -207,7 +208,8 @@ export default function HomeClient({ nextShow }: HomeClientProps) {
           aria-hidden="true"
         />
 
-        <div className="ornament mb-6 text-xl" aria-hidden="true">❦</div>
+        {/* The lone classic fleuron — page headers carry the logo mark instead */}
+        <Ornament className="mb-6 text-xl" glyph="❦" />
         <h2 className="font-display mb-8 text-center text-2xl text-cream sm:text-3xl">
           {latestVideo?.title ?? (isLoadingVideo ? 'Tuning up…' : 'New video coming soon')}
         </h2>

--- a/app/components/motion-provider.tsx
+++ b/app/components/motion-provider.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import { MotionConfig } from 'framer-motion'
+import type { ReactNode } from 'react'
+
+// Honors prefers-reduced-motion for every Framer Motion animation:
+// transform/layout animations are skipped, opacity fades still run.
+export default function MotionProvider({ children }: { children: ReactNode }) {
+  return <MotionConfig reducedMotion="user">{children}</MotionConfig>
+}

--- a/app/components/ornament.tsx
+++ b/app/components/ornament.tsx
@@ -1,0 +1,25 @@
+import Image from 'next/image'
+
+interface OrnamentProps {
+  className?: string
+  /** Render a classic fleuron character instead of the logo mark. */
+  glyph?: string
+}
+
+// Section divider:  ── ✕ ──  where ✕ is the band's guitar-redwood mark
+// by default (a printer's mark between the rules), or a fleuron glyph.
+export default function Ornament({ className = '', glyph }: OrnamentProps) {
+  return (
+    <div className={`ornament ${className}`.trim()} aria-hidden="true">
+      {glyph ?? (
+        <Image
+          src="/logonotext.svg"
+          alt=""
+          width={15}
+          height={44}
+          className="logo-cream h-11 w-auto opacity-80"
+        />
+      )}
+    </div>
+  )
+}

--- a/app/global.css
+++ b/app/global.css
@@ -31,6 +31,12 @@ html {
   color-scheme: dark;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 html,
 body {
   overflow-x: clip;
@@ -76,6 +82,21 @@ body {
   opacity: 0.05;
   z-index: 40;
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+}
+
+/* Printer's-mark watermark: the logo line art, fixed and faint behind
+   page content so the open pine midsections carry a little texture */
+.watermark-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image: url('/logonotext.svg');
+  background-repeat: no-repeat;
+  background-position: center 42%;
+  background-size: auto min(58vmin, 30rem);
+  filter: brightness(0) invert(0.96) sepia(0.22);
+  opacity: 0.04;
 }
 
 /* Palette utilities */
@@ -223,6 +244,29 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .aurora {
     animation: none;
+  }
+}
+
+/* Ticket-stub perforation: punch-hole bites where the date-column
+   divider meets the card edges. The divider is the right border of the
+   8rem date column inside the card's 1.5rem padding, so the holes sit
+   at 9.5rem (minus 1px to center on the 2px rule). Masks the card and
+   its hard offset shadow, so the bite carries through both. sm+ only —
+   the divider doesn't exist in the stacked mobile layout. If
+   mask-composite is unsupported the layers union to fully opaque and
+   the card simply renders without bites. */
+@media (min-width: 640px) {
+  .ticket-stub {
+    --punch-r: 0.4rem;
+    --punch-x: calc(9.5rem - 1px);
+    -webkit-mask-image:
+      radial-gradient(circle var(--punch-r) at var(--punch-x) 0, transparent calc(var(--punch-r) - 1px), #000 var(--punch-r)),
+      radial-gradient(circle var(--punch-r) at var(--punch-x) 100%, transparent calc(var(--punch-r) - 1px), #000 var(--punch-r));
+    -webkit-mask-composite: source-in;
+    mask-image:
+      radial-gradient(circle var(--punch-r) at var(--punch-x) 0, transparent calc(var(--punch-r) - 1px), #000 var(--punch-r)),
+      radial-gradient(circle var(--punch-r) at var(--punch-x) 100%, transparent calc(var(--punch-r) - 1px), #000 var(--punch-r));
+    mask-composite: intersect;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 import { Fraunces, Alegreya_Sans } from 'next/font/google'
 import { Navbar } from './components/nav'
 import Footer from './components/footer'
+import MotionProvider from './components/motion-provider'
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import { baseUrl } from './sitemap'
@@ -70,10 +71,13 @@ export default function RootLayout({
     >
       <body className="antialiased min-h-screen">
         <div className="grain-overlay"></div>
+        <div className="watermark-overlay" aria-hidden="true"></div>
         <main className="relative z-10">
-          <Navbar />
-          {children}
-          <Footer />
+          <MotionProvider>
+            <Navbar />
+            {children}
+            <Footer />
+          </MotionProvider>
           <Analytics />
           <SpeedInsights />
         </main>

--- a/app/music/page.tsx
+++ b/app/music/page.tsx
@@ -1,4 +1,5 @@
 import { Youtube } from 'lucide-react'
+import Ornament from '@/app/components/ornament'
 
 export const metadata = {
   title: 'Music',
@@ -12,7 +13,7 @@ export default function MusicPage() {
         <header className="mb-12 text-center">
           <h1 className="font-display vintage-shadow text-5xl text-cream sm:text-6xl">Live at G-Fest 2025</h1>
           <p className="mt-4 text-sand/80">September 27, 2025 · Petaluma, CA</p>
-          <div className="ornament mt-6 text-xl" aria-hidden="true">❦</div>
+          <Ornament className="mt-6" />
         </header>
 
         {/* Full show — taper-style soundboard from the Internet Archive */}

--- a/app/shows/shows-client.tsx
+++ b/app/shows/shows-client.tsx
@@ -1,10 +1,24 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { MapPin, Clock, Ticket, ChevronRight } from 'lucide-react'
+import { MapPin, Clock, Ticket, ChevronRight, CalendarPlus } from 'lucide-react'
 import type { Show } from '@/types/content'
 import { getDateParts, getWeekday } from '@/lib/dates'
+import { buildShowIcs, showIcsFilename } from '@/lib/calendar'
 import SubscribeForm from '@/app/components/subscribe-form'
+import Ornament from '@/app/components/ornament'
+
+function downloadShowIcs(show: Show) {
+  const ics = buildShowIcs(show)
+  if (!ics) return
+
+  const url = URL.createObjectURL(new Blob([ics], { type: 'text/calendar;charset=utf-8' }))
+  const link = document.createElement('a')
+  link.href = url
+  link.download = showIcsFilename(show)
+  link.click()
+  URL.revokeObjectURL(url)
+}
 
 interface ShowsPageProps {
   title: string
@@ -22,7 +36,7 @@ export default function ShowsClient({ title, shows, nextShowIndex }: ShowsPagePr
           className="mb-14 text-center"
         >
           <h1 className="font-display vintage-shadow text-5xl text-cream sm:text-6xl">{title}</h1>
-          <div className="ornament mt-6 text-xl" aria-hidden="true">❦</div>
+          <Ornament className="mt-6" />
         </motion.header>
 
         <motion.div
@@ -46,74 +60,89 @@ export default function ShowsClient({ title, shows, nextShowIndex }: ShowsPagePr
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: index * 0.08 }}
-                className={`relative flex flex-col gap-5 border-2 p-6 transition-colors sm:flex-row sm:items-center sm:gap-8 ${
-                  isNext
-                    ? 'border-gold/70 bg-moss/50 shadow-[6px_6px_0_rgba(233,185,73,0.25)]'
-                    : 'border-rust/30 bg-pine/40 hover:border-rust/60 hover:bg-moss/30'
-                }`}
+                className="relative"
               >
+                {/* Badge sits outside the masked card so the punch holes can't clip it */}
                 {isNext && (
-                  <span className="absolute -top-3 left-5 bg-gold px-3 py-0.5 text-[0.65rem] font-bold uppercase tracking-[0.25em] text-pine">
+                  <span className="absolute -top-3 left-5 z-10 bg-gold px-3 py-0.5 text-[0.65rem] font-bold uppercase tracking-[0.25em] text-pine">
                     Next Show
                   </span>
                 )}
 
-                {/* Date block — torn off a wall calendar */}
-                {parts ? (
-                  <div className="flex shrink-0 items-center gap-4 sm:w-32 sm:flex-col sm:gap-0 sm:border-r-2 sm:border-rust/30 sm:pr-8 sm:text-center">
-                    <div>
-                      <p className="text-xs font-bold uppercase tracking-[0.3em] text-rust">
-                        {weekday?.slice(0, 3)} · {parts.month}
-                      </p>
-                      <p className="font-display text-5xl leading-none text-cream sm:text-6xl">{parts.day}</p>
-                      <p className="mt-1 text-xs tracking-[0.2em] text-sand/60">{parts.year}</p>
+                <div
+                  className={`ticket-stub flex flex-col gap-5 border-2 p-6 transition-colors sm:flex-row sm:items-center sm:gap-8 ${
+                    isNext
+                      ? 'border-gold/70 bg-moss/50 shadow-[6px_6px_0_rgba(233,185,73,0.25)]'
+                      : 'border-rust/30 bg-pine/40 hover:border-rust/60 hover:bg-moss/30'
+                  }`}
+                >
+                  {/* Date block — the tear-off stub, perforation and all */}
+                  {parts ? (
+                    <div className="flex shrink-0 items-center gap-4 sm:w-32 sm:flex-col sm:gap-0 sm:border-r-2 sm:border-dashed sm:border-rust/40 sm:pr-8 sm:text-center">
+                      <div>
+                        <p className="text-xs font-bold uppercase tracking-[0.3em] text-rust">
+                          {weekday?.slice(0, 3)} · {parts.month}
+                        </p>
+                        <p className="font-display text-5xl leading-none text-cream sm:text-6xl">{parts.day}</p>
+                        <p className="mt-1 text-xs tracking-[0.2em] text-sand/60">{parts.year}</p>
+                      </div>
                     </div>
-                  </div>
-                ) : (
-                  <div className="shrink-0 sm:w-32 sm:border-r-2 sm:border-rust/30 sm:pr-8 sm:text-center">
-                    <p className="font-display text-2xl text-cream">{show.date}</p>
-                  </div>
-                )}
+                  ) : (
+                    <div className="shrink-0 sm:w-32 sm:border-r-2 sm:border-dashed sm:border-rust/40 sm:pr-8 sm:text-center">
+                      <p className="font-display text-2xl text-cream">{show.date}</p>
+                    </div>
+                  )}
 
-                {/* Venue + details */}
-                <div className="min-w-0 flex-1">
-                  <h3 className="font-display text-2xl text-cream sm:text-3xl">{show.venue}</h3>
-                  <div className="mt-2 flex flex-wrap items-center gap-x-5 gap-y-1 text-sand">
-                    <span className="flex items-center gap-1.5">
-                      <MapPin size={16} className="shrink-0 text-rust" />
-                      {show.location}
-                    </span>
-                    {show.time && (
+                  {/* Venue + details */}
+                  <div className="min-w-0 flex-1">
+                    <h3 className="font-display text-2xl text-cream sm:text-3xl">{show.venue}</h3>
+                    <div className="mt-2 flex flex-wrap items-center gap-x-5 gap-y-1 text-sand">
                       <span className="flex items-center gap-1.5">
-                        <Clock size={16} className="shrink-0 text-rust" />
-                        {show.time}
+                        <MapPin size={16} className="shrink-0 text-rust" />
+                        {show.location}
                       </span>
+                      {show.time && (
+                        <span className="flex items-center gap-1.5">
+                          <Clock size={16} className="shrink-0 text-rust" />
+                          {show.time}
+                        </span>
+                      )}
+                    </div>
+                    {show.description && (
+                      <p className="mt-3 text-sm italic leading-relaxed text-sand/80">{show.description}</p>
+                    )}
+                    {parts && (
+                      <button
+                        type="button"
+                        onClick={() => downloadShowIcs(show)}
+                        className="mt-3 inline-flex items-center gap-1.5 text-[0.7rem] font-bold uppercase tracking-[0.2em] text-rust/80 transition-colors hover:text-gold"
+                      >
+                        <CalendarPlus size={14} className="shrink-0" />
+                        Add to Calendar
+                      </button>
                     )}
                   </div>
-                  {show.description && (
-                    <p className="mt-3 text-sm italic leading-relaxed text-sand/80">{show.description}</p>
+
+                  {/* Tickets / status */}
+                  {(show.soldOut || show.hasTickets) && (
+                    <div className="shrink-0 sm:self-center">
+                      {show.soldOut ? (
+                        <span className="font-bold uppercase tracking-[0.2em] text-burgundy">Sold Out</span>
+                      ) : (
+                        <a
+                          href={show.ticketsUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="group inline-flex items-center gap-2 border-2 border-gold/70 px-4 py-2 text-sm font-bold uppercase tracking-[0.15em] text-gold transition-colors hover:bg-gold hover:text-pine"
+                        >
+                          <Ticket size={16} />
+                          Tickets
+                          <ChevronRight size={14} className="transition-transform group-hover:translate-x-1" />
+                        </a>
+                      )}
+                    </div>
                   )}
                 </div>
-
-                {/* Tickets / status */}
-                {(show.soldOut || show.hasTickets) && (
-                  <div className="shrink-0 sm:self-center">
-                    {show.soldOut ? (
-                      <span className="font-bold uppercase tracking-[0.2em] text-burgundy">Sold Out</span>
-                    ) : (
-                      <a
-                        href={show.ticketsUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="group inline-flex items-center gap-2 border-2 border-gold/70 px-4 py-2 text-sm font-bold uppercase tracking-[0.15em] text-gold transition-colors hover:bg-gold hover:text-pine"
-                      >
-                        <Ticket size={16} />
-                        Tickets
-                        <ChevronRight size={14} className="transition-transform group-hover:translate-x-1" />
-                      </a>
-                    )}
-                  </div>
-                )}
               </motion.article>
             )
           })}

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1,0 +1,137 @@
+import type { Show } from '@/types/content'
+import { parseShowDate } from './dates'
+
+type TimeOfDay = { hours: number; minutes: number }
+
+const DEFAULT_DURATION_HOURS = 2
+
+// Show times are loose strings like "6:00–8:00 PM" or "7 PM". A meridiem
+// given on only one side applies to both ("6:00–8:00 PM" → 6 PM to 8 PM).
+function parseTimeRange(value: string): { start: TimeOfDay; end: TimeOfDay | null } | null {
+  const tokens = [...value.matchAll(/(\d{1,2})(?::(\d{2}))?\s*(am|pm)?/gi)]
+    .map((match) => ({
+      hours: Number(match[1]),
+      minutes: match[2] ? Number(match[2]) : 0,
+      meridiem: match[3]?.toLowerCase() ?? null,
+    }))
+    .slice(0, 2)
+
+  if (tokens.length === 0) return null
+
+  const sharedMeridiem = tokens.find((token) => token.meridiem)?.meridiem ?? null
+
+  const toTimeOfDay = (token: (typeof tokens)[number]): TimeOfDay | null => {
+    if (token.hours > 23 || token.minutes > 59) return null
+    const meridiem = token.meridiem ?? sharedMeridiem
+    let hours = token.hours
+    if (meridiem === 'pm' && hours < 12) hours += 12
+    if (meridiem === 'am' && hours === 12) hours = 0
+    return { hours, minutes: token.minutes }
+  }
+
+  const start = toTimeOfDay(tokens[0])
+  if (!start) return null
+
+  return { start, end: tokens[1] ? toTimeOfDay(tokens[1]) : null }
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
+function formatDate(date: Date): string {
+  return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}`
+}
+
+// Floating local time (no TZID) — shows are local affairs, so the event
+// should land at the venue's wall-clock time on every device.
+function formatLocalDateTime(date: Date): string {
+  return `${formatDate(date)}T${pad(date.getHours())}${pad(date.getMinutes())}00`
+}
+
+function escapeText(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r?\n/g, '\\n')
+}
+
+// RFC 5545 §3.1: content lines over 75 octets must be folded with a
+// CRLF + single space continuation.
+function foldLine(line: string): string {
+  const segments: string[] = []
+  let rest = line
+  while (rest.length > 74) {
+    segments.push(rest.slice(0, 74))
+    rest = ' ' + rest.slice(74)
+  }
+  segments.push(rest)
+  return segments.join('\r\n')
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+export function buildShowIcs(show: Show): string | null {
+  const date = parseShowDate(show.date)
+  if (!date) return null
+
+  const range = show.time ? parseTimeRange(show.time) : null
+
+  let dtStart: string
+  let dtEnd: string
+  if (range) {
+    const start = new Date(date)
+    start.setHours(range.start.hours, range.start.minutes, 0, 0)
+    const end = new Date(date)
+    if (range.end) {
+      end.setHours(range.end.hours, range.end.minutes, 0, 0)
+    } else {
+      end.setHours(range.start.hours + DEFAULT_DURATION_HOURS, range.start.minutes, 0, 0)
+    }
+    if (end <= start) {
+      end.setDate(end.getDate() + 1)
+    }
+    dtStart = `DTSTART:${formatLocalDateTime(start)}`
+    dtEnd = `DTEND:${formatLocalDateTime(end)}`
+  } else {
+    const nextDay = new Date(date)
+    nextDay.setDate(nextDay.getDate() + 1)
+    dtStart = `DTSTART;VALUE=DATE:${formatDate(date)}`
+    dtEnd = `DTEND;VALUE=DATE:${formatDate(nextDay)}`
+  }
+
+  const stamp = new Date()
+  const dtStamp =
+    `${stamp.getUTCFullYear()}${pad(stamp.getUTCMonth() + 1)}${pad(stamp.getUTCDate())}` +
+    `T${pad(stamp.getUTCHours())}${pad(stamp.getUTCMinutes())}${pad(stamp.getUTCSeconds())}Z`
+
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Northern Disconnection//Shows//EN',
+    'BEGIN:VEVENT',
+    `UID:${formatDate(date)}-${slugify(show.venue)}@northerndisconnection`,
+    `DTSTAMP:${dtStamp}`,
+    dtStart,
+    dtEnd,
+    `SUMMARY:${escapeText(`Northern Disconnection at ${show.venue}`)}`,
+    `LOCATION:${escapeText(`${show.venue}, ${show.location}`)}`,
+  ]
+  if (show.description) {
+    lines.push(`DESCRIPTION:${escapeText(show.description)}`)
+  }
+  lines.push('END:VEVENT', 'END:VCALENDAR')
+
+  return lines.map(foldLine).join('\r\n') + '\r\n'
+}
+
+export function showIcsFilename(show: Show): string {
+  const date = parseShowDate(show.date)
+  return `northern-disconnection-${date ? formatDate(date) : 'show'}-${slugify(show.venue)}.ics`
+}


### PR DESCRIPTION
## Summary
Enhances the shows page with iCalendar (.ics) export functionality and improves accessibility and visual design across the site. Adds motion preference support, refactors ornament rendering, and introduces a watermark overlay.

## Key Changes

- **Calendar Export**: Added `lib/calendar.ts` with RFC 5545-compliant iCalendar generation. Shows with parsed dates now display an "Add to Calendar" button that downloads a `.ics` file with event details (venue, location, time range with 2-hour default duration).

- **Ornament Component**: Extracted `app/components/ornament.tsx` to replace inline fleuron markup. Renders the logo mark as a centered divider by default, with optional glyph override. Updated all pages (`shows-client.tsx`, `home-client.tsx`, `about/page.tsx`, `music/page.tsx`) to use the new component.

- **Motion Accessibility**: Created `app/components/motion-provider.tsx` wrapping the layout with Framer Motion's `MotionConfig` set to `reducedMotion="user"`. Honors `prefers-reduced-motion` system preference globally. Added CSS rule to disable smooth scroll behavior when motion is reduced.

- **Visual Refinements**:
  - Ticket-stub perforation: Added `.ticket-stub` CSS mask on sm+ breakpoints to punch circular holes where the date column divider meets card edges, enhancing the torn-off ticket aesthetic.
  - Watermark overlay: Added fixed background watermark (logo mark, faint and sepia-tinted) behind page content for texture.
  - Divider styling: Changed date-column border from solid to dashed (`border-dashed`) with adjusted opacity for a more authentic perforated look.

- **Layout Structure**: Wrapped `Navbar`, page content, and `Footer` in `MotionProvider` within `app/layout.tsx`. Added watermark overlay div to body.

## Implementation Details

- Time parsing in `buildShowIcs()` handles loose formats ("6:00–8:00 PM", "7 PM") with shared meridiem inference across ranges.
- iCalendar UID uses date + slugified venue for uniqueness; filename follows same pattern.
- Punch-hole masks use CSS `mask-composite: intersect` (with `-webkit-` fallback) to apply holes to both the card and its offset shadow.
- Ornament component accepts optional `glyph` prop for flexibility; defaults to logo image with cream color filter.

https://claude.ai/code/session_018BiSCtmCvKPSFtiz6PwXZx